### PR TITLE
Remove unnecessary vendor prefix

### DIFF
--- a/src/sass/objects/_objects.grid.flex.scss
+++ b/src/sass/objects/_objects.grid.flex.scss
@@ -21,9 +21,7 @@
 
     @supports (display: flex) {
         justify-content: flex-start;
-        display: -webkit-flex;
         display: flex;
-        -webkit-flex-wrap: wrap;
         flex-wrap: wrap;
         > * {
             width: 100%;

--- a/src/sass/objects/_objects.grid.flex.scss
+++ b/src/sass/objects/_objects.grid.flex.scss
@@ -23,8 +23,5 @@
         justify-content: flex-start;
         display: flex;
         flex-wrap: wrap;
-        > * {
-            width: 100%;
-        }
     }
 }


### PR DESCRIPTION
We shouldn't need to declare these since using postcss/autoprefixer plugin etc etc?